### PR TITLE
Harry/v2

### DIFF
--- a/eventual.go
+++ b/eventual.go
@@ -1,176 +1,86 @@
-// Package eventual provides values that eventually have a value.
 package eventual
 
 import (
-	"math"
+	"context"
 	"sync"
-	"sync/atomic"
-	"time"
 )
 
-const (
-	// Forever indicates that Get should wait forever
-	Forever = -1
-)
+// DontWait is an expired context for use in Value.Get. Using DontWait will cause a Value.Get call
+// to return immediately. If the value has not been set, a context.Canceled error will be returned.
+var DontWait context.Context
 
-// Value is an eventual value, meaning that callers wishing to access the value
-// block until the value is available.
-type Value interface {
-	// Set sets this Value to the given val.
-	Set(val interface{})
-
-	// Get waits up to timeout for the value to be set and returns it, or returns
-	// nil if it times out or Cancel() is called. valid will be false in latter
-	// case. If timeout is 0, Get won't wait. If timeout is -1, Get will wait
-	// forever.
-	Get(timeout time.Duration) (ret interface{}, valid bool)
-
-	// Cancel cancels this value, signaling any waiting calls to Get() that no
-	// value is coming. If no value was set before Cancel() was called, all future
-	// calls to Get() will return nil, false. Subsequent calls to Set after Cancel
-	// have no effect.
-	Cancel()
+func init() {
+	var cancel func()
+	DontWait, cancel = context.WithCancel(context.Background())
+	cancel()
 }
 
-// Getter is a functional interface for the Value.Get function
-type Getter func(time.Duration) (interface{}, bool)
+// Value is an eventual value, meaning that callers wishing to access the value block until it is
+// available.
+type Value interface {
+	// Set this Value.
+	Set(interface{})
+
+	// Get waits for the value to be set. If the context expires first, an error will be returned.
+	//
+	// This function will return immediately when called with an expired context. In this case, the
+	// value will be returned only if it has already been set; otherwise the context error will be
+	// returned. For convenience, see DontWait.
+	Get(context.Context) (interface{}, error)
+}
+
+// NewValue creates a new value.
+func NewValue() Value {
+	return WithDefault(nil)
+}
+
+// WithDefault creates a new value that returns the given defaultValue if a real value isn't
+// available in time.
+func WithDefault(defaultValue interface{}) Value {
+	return &value{defaultValue: defaultValue}
+}
 
 type value struct {
-	state   atomic.Value
-	waiters []chan interface{}
-	mutex   sync.Mutex
+	m            sync.Mutex
+	v            interface{}
+	defaultValue interface{}
+	set          bool
+	waiters      []chan interface{}
 }
 
-type stateholder struct {
-	val      interface{}
-	set      bool
-	canceled bool
-}
-
-// NewValue creates a new Value.
-func NewValue() Value {
-	result := &value{waiters: make([]chan interface{}, 0)}
-	result.state.Store(&stateholder{})
-	return result
-}
-
-// DefaultGetter builds a Getter that always returns the supplied value.
-func DefaultGetter(val interface{}) Getter {
-	return func(time.Duration) (interface{}, bool) {
-		return val, true
-	}
-}
-
-// DefaultUnsetGetter builds a Getter that always !ok.
-func DefaultUnsetGetter() Getter {
-	return func(time.Duration) (interface{}, bool) {
-		return nil, false
-	}
-}
-
-func (v *value) Set(val interface{}) {
-	v.mutex.Lock()
-	defer v.mutex.Unlock()
-
-	state := v.getState()
-	settable := !state.canceled
-	if settable {
-		v.setState(&stateholder{
-			val:      val,
-			set:      true,
-			canceled: false,
-		})
-
-		if v.waiters != nil {
-			// Notify anyone waiting for value
-			for _, waiter := range v.waiters {
-				waiter <- val
-			}
-			// Clear waiters
-			v.waiters = nil
-		}
-	}
-}
-
-func (v *value) Cancel() {
-	v.mutex.Lock()
-	defer v.mutex.Unlock()
-
-	state := v.getState()
-	v.setState(&stateholder{
-		val:      state.val,
-		set:      state.set,
-		canceled: true,
-	})
-
-	if v.waiters != nil {
-		// Notify anyone waiting for value
+func (v *value) Set(i interface{}) {
+	v.m.Lock()
+	v.v = i
+	if !v.set {
+		// This is our first time setting, inform anyone who is waiting
 		for _, waiter := range v.waiters {
-			close(waiter)
+			waiter <- i
 		}
-		// Clear waiters
-		v.waiters = nil
+		v.set = true
 	}
+	v.m.Unlock()
 }
 
-func (v *value) Get(timeout time.Duration) (ret interface{}, valid bool) {
-	state := v.getState()
-
-	// First check for existing value using atomic operations (for speed)
-	if state.set {
-		// Value found, use it
-		return state.val, true
-	} else if state.canceled {
-		// Value was canceled, return false
-		return nil, false
+func (v *value) Get(ctx context.Context) (interface{}, error) {
+	v.m.Lock()
+	if v.set {
+		// Value already set, use existing
+		_v := v.v
+		v.m.Unlock()
+		return _v, nil
 	}
 
-	if timeout == 0 {
-		// Don't wait
-		return nil, false
-	}
-
-	// If we didn't find an existing value, try again but this time using locking
-	v.mutex.Lock()
-	state = v.getState()
-
-	if state.set {
-		// Value found, use it
-		v.mutex.Unlock()
-		return state.val, true
-	} else if state.canceled {
-		// Value was canceled, return false
-		v.mutex.Unlock()
-		return nil, false
-	}
-
-	if timeout == -1 {
-		// Wait essentially forever
-		timeout = time.Duration(math.MaxInt64)
-	}
-
-	// Value not found, register to be notified once value is set
-	valCh := make(chan interface{}, 1)
-	v.waiters = append(v.waiters, valCh)
-	v.mutex.Unlock()
-
-	// Wait up to timeout for value to get set
+	// Value not yet set, wait
+	waiter := make(chan interface{}, 1)
+	v.waiters = append(v.waiters, waiter)
+	v.m.Unlock()
 	select {
-	case v, ok := <-valCh:
-		return v, ok
-	case <-time.After(timeout):
-		return nil, false
+	case _v := <-waiter:
+		return _v, nil
+	case <-ctx.Done():
+		if v.defaultValue != nil {
+			return v.defaultValue, nil
+		}
+		return nil, ctx.Err()
 	}
-}
-
-func (v *value) getState() *stateholder {
-	state := v.state.Load()
-	if state == nil {
-		return nil
-	}
-	return state.(*stateholder)
-}
-
-func (v *value) setState(state *stateholder) {
-	v.state.Store(state)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
-module github.com/getlantern/eventual
+module github.com/getlantern/eventual/v2
 
 go 1.13
 
-require (
-	github.com/getlantern/grtrack v0.0.0-20160824195228-cbf67d3fa0fd
-	github.com/stretchr/testify v1.6.1
-)
+require github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/getlantern/eventual
+
+go 1.13
+
+require (
+	github.com/getlantern/grtrack v0.0.0-20160824195228-cbf67d3fa0fd
+	github.com/stretchr/testify v1.6.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/getlantern/grtrack v0.0.0-20160824195228-cbf67d3fa0fd h1:GPrx88jy222gMuRHXxBSViT/3zdNO210nRAaXn+lL6s=
-github.com/getlantern/grtrack v0.0.0-20160824195228-cbf67d3fa0fd/go.mod h1:RkQEgBdrJCH5tYJP2D+a/aJ216V3c9q8w/tCJtEiDoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/getlantern/grtrack v0.0.0-20160824195228-cbf67d3fa0fd h1:GPrx88jy222gMuRHXxBSViT/3zdNO210nRAaXn+lL6s=
+github.com/getlantern/grtrack v0.0.0-20160824195228-cbf67d3fa0fd/go.mod h1:RkQEgBdrJCH5tYJP2D+a/aJ216V3c9q8w/tCJtEiDoY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
I was doing some work in flashlight and was trying to use a `context.Context` together with an `eventual.Value`.  It was a little hacky, so I decided to see what it'd look like if I updated the `eventual` API to accept contexts.

Personally, I like the result.  Contexts are more versatile and, IMO, easier to use in many cases than a timeout.  A couple of examples:
- Contexts can be cancelled based on runtime decisions (e.g. "Did this other thing happen already?").
- To implement a timeout across multiple blocking calls, we can just pass the same context to each.  This is in contrast to adjusting the current timeout after each call to account for elapsed time.  Even better, we can accept a context ourselves and not worry about what the timeout should be.

AFAICT, we retain the core functionality of this package:
- To call `Get` with a specified timeout, we use `context.WithTimeout`.
- To call `Get` with no timeout, we use `context.Background`.
- To call `Get` without waiting, we use an expired context (call `context.WithCancel`, cancel it, and use that).
- To cancel all waiters on a value, give them all contexts rooted in the same parent context and cancel that parent.

What's missing / changed is the following:
- While you can cancel a group of waiters as noted above, there is no mechanism to "freeze" a Value (this was a side effect of Value.Cancel previously).  If necessary, I can make this happen, but I suspect it was more of an artifact of the implementation than a design goal.
- There is no exact equivalent to `DefaultGetter`.  I added the convenience function `WithDefault`, which I think is in the spirit of `DefaultGetter`, but not exactly the same in that it can still be set to a new value.  I only found [one use of DefaultGetter](https://github.com/getlantern/analytics/blob/4f3356be8d338f00bcdcdd8767b453c8a32fba5b/analytics.go#L78) in our code (ignoring tests and dead code) and it seems that `WithDefault` will work there.
- There is no equivalent to `DefaultUnsetGetter`.  Again, there was only [one use of this function](https://github.com/getlantern/flashlight/blob/ce2bd21d7efc6318736afec516f83040815b5441/proxied/proxied.go#L41) in our code (ignoring dead code).  From what I can tell there, the idea is that before `proxyAddr` has been set, we want to return `ErrChainedProxyUnavailable`.  Once `proxyAddr` has been set, we want to wait for the concrete value.  This can be achieved by just setting `proxyAddr` to `nil` first.  We're already synchronizing access via `proxyAddrLock`.
- `Get` is a little slower.  To be precise, I previously benchmarked it at ~ 4 ns / op and now benchmark it at ~ 15 ns / op.  I can't imagine this is difference is big enough to matter.  I figured I'd highlight it though as I saw some notes about performance in the code.

A few final points about these changes:
- With Go modules, we can import the old version and the new version of the package simultaneously (even in the same file).  So migration and support of older code will not be an issue.
- My plan, if this gets merged, is to tag the first commit in this PR as `v1.0.0` and the second commit as `v2.0.0`.
- The diff is pretty mangled, so it's probably easier to just look at the new code on its own.

Finally, sorry this write-up has become so long... I've just seen this package used quite a bit, so I wanted to explain my reasoning with this new API.